### PR TITLE
feat: add tryacquire function

### DIFF
--- a/semaphore_test.go
+++ b/semaphore_test.go
@@ -109,3 +109,24 @@ func TestAcquire(t *testing.T) {
 		a.ErrorIs(err, context.Canceled)
 	})
 }
+
+func TestTryAcquire(t *testing.T) {
+	a := assert.New(t)
+
+	t.Run("Successful", func(t *testing.T) {
+		r := New(1)
+
+		a.True(r.TryAcquire())
+		defer r.Release()
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		r := New(1)
+
+		ctx := context.Background()
+		a.NoError(r.Acquire(ctx))
+
+		defer r.Release()
+		a.False(r.TryAcquire())
+	})
+}


### PR DESCRIPTION
Adds a TryAcquire function, which will attempt to acquire a lock if slots are available. A boolean indicating wether a slot was acquired is returned.

closes #6